### PR TITLE
fix(docker): correct database setup in `docker-compose` and `entrypoint`

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,8 +1,13 @@
 #!/bin/bash -e
 
 # If running the rails server then create or migrate existing database
-if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
+if [ "${1}" == "./bin/rails" ] && [ "${2}" = "server" ]; then
   ./bin/rails db:prepare
+  ./bin/rails db:prepare RAILS_ENV=test
+fi
+
+if [ -f tmp/pids/server.pid ]; then
+  rm tmp/pids/server.pid
 fi
 
 exec "${@}"

--- a/config/database.yml
+++ b/config/database.yml
@@ -55,7 +55,7 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *defaultp
+  <<: *default
   database: store_test
   url: <%= ENV['DATABASE_URL'] %>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
     db:
         image: postgres:16-alpine
@@ -17,17 +15,31 @@ services:
         volumes:
         - redis_data:/data  
     web:
-        ## TODO
+        build: .
+        entrypoint: ['sh', 'bin/docker-entrypoint']
+        command: bundle exec rails db:create db:schema:load db:seed && bundle exec rails s -p 3000 -b 0.0.0.0
+        tty: true
+        volumes:
+            - .:/app
+        ports:
+            - '3000:3000'
+        depends_on:
+            - db
+            - redis
+        environment:
+            - DATABASE_URL=postgresql://postgres:password@db:5432/store_development
+            - REDIS_URL=redis://redis:6379
     test:
         build: .
-        command: bundle exec rspec
+        command: bundle exec rails db:create db:migrate RAILS_ENV=test && bundle exec rspec
         volumes:
             - .:/rails
         depends_on:
             - db
             - redis 
         environment:
-            - DATABASE_URL: postgresql://postgres:password@db:5432/myapp_test
-            - REDIS_URL: redis://redis:6379/0
+            - DATABASE_URL=postgresql://postgres:password@db:5432/store_test
+            - REDIS_URL=redis://redis:6379/0
 volumes:
     postgres13:
+    redis_data:


### PR DESCRIPTION
# Problem

:ticket: [Link to the issue](https://TODO)

This PR addresses several issues related to the Dockerized environment setup, specifically concerning database initialization and 
environment configuration.
*   **What was your customer problem?** The Docker setup was not correctly initializing the database for both development/production 
and test environments, leading to potential errors when running the application or tests within Docker. The `server.pid` file was also
causing issues on server restarts.
*   **What bug does it fix?**
    *   Incorrect database preparation for the test environment in `docker-entrypoint`.
    *   Typo in `config/database.yml` preventing correct inheritance of default settings for the test database.
    *   Missing `db:create` and `db:migrate` steps for the test environment in `docker-compose.yml`'s `test` service.
    *   Potential `server.pid` conflicts when restarting the Rails server in Docker.
    *   Incomplete `docker-compose.yml` configuration for the `web` service (build, entrypoint, command, volumes, ports, dependencies,
environment variables).
*   **What code technical debt it removes?** It improves the robustness and correctness of the Docker setup, reducing future debugging
efforts related to environment configuration.

# Solution

This PR provides a comprehensive fix for the Docker environment setup, ensuring proper database initialization and application 
execution.
*   **How this PR solve your customer problem?**
    *   **`bin/docker-entrypoint`**: Now includes `db:prepare RAILS_ENV=test` to correctly set up the test database and `rm 
tmp/pids/server.pid` to prevent server startup issues.
    *   **`config/database.yml`**: Corrects `<<: *defaultp` to `<<: *default` for the `test` environment, ensuring it inherits the 
correct default database settings.
    *   **`docker-compose.yml`**:
        *   **`web` service**: Fully configures the `web` service with `build`, `entrypoint`, `command` (including `db:create 
db:schema:load db:seed`), `tty`, `volumes`, `ports`, `depends_on` (db, redis), and correct `DATABASE_URL` and `REDIS_URL` environment 
variables.
        *   **`test` service**: Updates the `command` to `bundle exec rails db:create db:migrate RAILS_ENV=test && bundle exec rspec` 
to ensure the test database is prepared before running tests. Also corrects the `DATABASE_URL` environment variable.
        *   Adds `redis_data` to the top-level `volumes` definition.
*   **How does the interface (UI or API) look like ?** This PR primarily affects the infrastructure and setup, not the application's 
UI or API directly. The API should now function correctly when run via Docker Compose.
*   **How was the bug fixed?** By systematically correcting configuration files (`docker-compose.yml`, `config/database.yml`) and the 
`docker-entrypoint` script to ensure all necessary database setup and environment variables are correctly applied within the Docker 
containers.
*   **How was the code improved?** The Docker setup is now more robust, self-contained, and correctly initializes the application and 
test environments, making development and testing more reliable.

# Testing

## Setup

1.  Ensure Docker and Docker Compose are installed.
2.  Navigate to the project root directory.
3.  Run `docker-compose build` to build the service images.

## Main scenarios

### Scenario 1: Start the development server via Docker Compose

*   **What are the steps to reproduce this scenario?**
    1.  From the project root, run `docker-compose up web`
*   **What is the expected outcome?**
    *   The `web` service should start successfully.
    *   The Rails application should be accessible at `http://localhost:3000`.
    *   The database should be created, schema loaded, and seeds run automatically.
    *   No errors related to database connection or `server.pid` should occur.

### Scenario 2: Run RSpec tests via Docker Compose

*   **What are the steps to reproduce this scenario?**
    1.  From the project root, run `docker-compose run test`
*   **What is the expected outcome?**
    *   The `test` service should execute.
    *   The test database should be created and migrated for the test environment.
    *   All RSpec tests should run successfully without database connection errors.

### Other scenarios

*   Verify that the `redis` service starts correctly and is accessible by the `web` service.
*   Try stopping and restarting the `web` service multiple times to ensure the `server.pid` cleanup works as expected.