### PR TITLE
feat(cart): add `/cart/add_item` endpoint and improve cart request specs

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,16 +1,31 @@
 class CartsController < ApplicationController
-  before_action :set_cart, only: [:show, :create]
-  before_action :set_product, only: [:create]
+  before_action :set_cart, only: [:show, :create, :add_item]
+  before_action :set_product, only: [:create, :add_item]
 
   def show
     render json: @cart
   end
 
   def create
+    existing_line_item = @cart.line_items.find_by(product_id: @product.id)
+
+    if existing_line_item
+      render json: {
+        error: "Product already in cart.",
+        message: "Use the /cart/add_item endpoint to update quantity."
+      }, status: :conflict
+    else
+      quantity = cart_params[:quantity].to_i
+      @cart.add_product(product: @product, quantity: quantity)
+      render json: @cart, status: :created
+    end
+  end
+
+  def add_item
     quantity = cart_params[:quantity].to_i
     @cart.add_product(product: @product, quantity: quantity)
 
-    render json: @cart, status: :created
+    render json: @cart, status: :ok
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   mount Sidekiq::Web => '/sidekiq'
   post '/cart', to: 'carts#create'
   get '/cart', to: 'carts#show'
+  post '/cart/add_item', to: 'carts#add_item'
+
   get "up" => "rails/health#show", as: :rails_health_check
 
   root "rails/health#show"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,8 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')

--- a/spec/requests/carts_spec.rb
+++ b/spec/requests/carts_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Carts", type: :request do
-  let!(:product) { create(:product) }
+RSpec.describe "/cart", type: :request do
+  let!(:product) { create(:product, name: "Test Product", price: 10.00) }
 
   describe "GET /cart" do
     it "creates a new cart if one doesn't exist in the session" do
@@ -9,13 +9,15 @@ RSpec.describe "Carts", type: :request do
 
       expect(response).to have_http_status(:ok)
       json_response = JSON.parse(response.body)
+      
       expect(json_response['id']).not_to be_nil
       expect(json_response['products']).to be_empty
+      expect(json_response['total_price']).to eq("0.0")
     end
 
     it "returns an existing cart from the session" do
-      post '/cart', params: { product_id: product.id, quantity: 1 }
-      expect(response).to have_http_status(:created)
+      post '/cart/add_item', params: { product_id: product.id, quantity: 1 }
+      expect(response).to have_http_status(:ok)
       created_cart_id = JSON.parse(response.body)['id']
 
       get '/cart'
@@ -28,8 +30,8 @@ RSpec.describe "Carts", type: :request do
   end
 
   describe "POST /cart" do
-    context "with valid parameters" do
-      it "adds a product to a new cart" do
+    context "with a new product" do
+      it "adds the product to the cart" do
         post '/cart', params: { product_id: product.id, quantity: 2 }
 
         expect(response).to have_http_status(:created)
@@ -37,24 +39,54 @@ RSpec.describe "Carts", type: :request do
         expect(json_response['products'].first['id']).to eq(product.id)
         expect(json_response['products'].first['quantity']).to eq(2)
       end
+    end
 
-      it "increases the quantity of an existing product in the cart" do
-        post '/cart', params: { product_id: product.id, quantity: 1 }
-        expect(response).to have_http_status(:created)
+    context "with a product that already exists in the cart" do
+      it "returns a conflict error and does not add the product" do
+        post '/cart/add_item', params: { product_id: product.id, quantity: 1 }
+        expect(response).to have_http_status(:ok)
 
         post '/cart', params: { product_id: product.id, quantity: 3 }
-        expect(response).to have_http_status(:created)
-
+        
+        expect(response).to have_http_status(:conflict)
+        
+        get '/cart'
         json_response = JSON.parse(response.body)
-        expect(json_response['products'].first['quantity']).to eq(4)
+        expect(json_response['products'].first['quantity']).to eq(1)
       end
     end
 
-    context "with invalid parameters" do
-      it "returns a not_found status if the product_id is invalid" do
+    context "with an invalid product" do
+      it "returns a not_found status" do
         post '/cart', params: { product_id: -1, quantity: 1 }
-        
         expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "POST /cart/add_item" do
+    context "with a new product" do
+      it "adds the product to the cart" do
+        post '/cart/add_item', params: { product_id: product.id, quantity: 2 }
+
+        expect(response).to have_http_status(:ok)
+        json_response = JSON.parse(response.body)
+        expect(json_response['products'].first['id']).to eq(product.id)
+        expect(json_response['products'].first['quantity']).to eq(2)
+      end
+    end
+
+    context "with a product that already exists in the cart" do
+      it "increases the quantity of the existing product" do
+        post '/cart/add_item', params: { product_id: product.id, quantity: 1 }
+        expect(response).to have_http_status(:ok)
+
+        post '/cart/add_item', params: { product_id: product.id, quantity: 3 }
+        expect(response).to have_http_status(:ok)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['products'].first['quantity']).to eq(4)
+        expect(json_response['total_price']).to eq("40.0")
       end
     end
   end


### PR DESCRIPTION
# Problem

:ticket: [Link to the issue](https://TODO)

The `POST /cart` endpoint had an ambiguous responsibility. It was responsible for both registering a new product in the cart and updating the quantity of an existing product. This did not strictly follow the API contract defined in the `README.md`, which specified distinct endpoints for each action. This ambiguity could lead to unexpected behavior for the API consumers.

# Solution

To address the problem and align the API with the specifications, this PR introduces the following changes:

* **Separation of Concerns:** The `POST /cart` endpoint is now strictly for registering a product that does **not yet exist** in the cart. If the product already exists, the API returns a `409 Conflict` error.
* **New Endpoint for Updates:** A new endpoint, `POST /cart/add_item`, has been created to handle both adding a product for the first time and updating the quantity of an existing product. This is now the recommended route for adding items to the cart.
* **Updated Tests:** The request specs (`carts_spec.rb`) have been completely rewritten to reflect the new API structure. They now cover all scenarios, including item creation, duplicate creation attempts, and quantity additions and updates, ensuring the expected behavior is correct and validated.
* **Test Configuration:** The `rails_helper.rb` has been updated to include the FactoryBot syntax, enabling cleaner and more readable tests.

# Testing

## Setup

To test the changes locally, ensure Docker is running and the project images have been built.

Run the following command in the project's root directory to execute the cart test suite:
```bash
docker compose run --rm test bundle exec rspec spec/requests/carts_spec.rb