### PR TITLE
docs(README): fix `JSON` examples and typos in API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,27 +30,27 @@ Adicionar o produto no carrinho e devolver o payload com a lista de produtos do 
 
 ROTA: `/cart`
 Payload:
-```js
+```json
 {
   "product_id": 345, // id do produto sendo adicionado
   "quantity": 2, // quantidade de produto a ser adicionado
 }
 ```
 
-Response
-```js
+Response:
+```json
 {
   "id": 789, // id do carrinho
   "products": [
     {
-      "id": 645,
+      "id": 345,
       "name": "Nome do produto",
       "quantity": 2,
       "unit_price": 1.99, // valor unitário do produto
       "total_price": 3.98, // valor total do produto
     },
     {
-      "id": 646,
+      "id": 346,
       "name": "Nome do produto 2",
       "quantity": 2,
       "unit_price": 1.99,
@@ -67,19 +67,19 @@ Criar um endpoint para listar os produtos no carrinho atual.
 ROTA: `/cart`
 
 Response:
-```js
+```json
 {
   "id": 789, // id do carrinho
   "products": [
     {
-      "id": 645,
+      "id": 345,
       "name": "Nome do produto",
       "quantity": 2,
       "unit_price": 1.99, // valor unitário do produto
       "total_price": 3.98, // valor total do produto
     },
     {
-      "id": 646,
+      "id": 346,
       "name": "Nome do produto 2",
       "quantity": 2,
       "unit_price": 1.99,
@@ -115,11 +115,11 @@ Response:
       "total_price": 14.00, 
     },
     {
-      "id": 01020,
+      "id": 1020,
       "name": "Nome do produto Y",
       "quantity": 1,
-      "unit_price": 9.90, 
-      "total_price": 9.90, 
+      "unit_price": 9.90,
+      "total_price": 9.90,
     },
   ],
   "total_price": 23.9


### PR DESCRIPTION
# Problem

:ticket: [Link to the issue](https://TODO)

The API documentation within the `README.md` file contained some errors that could confuse developers using the API.

* **Customer Problem:** Developers trying to understand the API endpoints were faced with incorrect and inconsistent documentation.
* **What bug does it fix?** It fixes bugs in the documentation where:
    * JSON code blocks were incorrectly labeled as `js`, leading to wrong syntax highlighting.
    * Example data was inconsistent. For instance, the product IDs in the API responses did not match the product IDs sent in the example requests.
    * There were typos in the example JSON data, such as an incorrect product ID `01020`.

# Solution

This pull request provides corrections to the API documentation in the `README.md` file to ensure it is accurate and clear.

* **How this PR solves your customer problem?** It provides developers with reliable and correct examples, making it easier to understand and integrate with the API.
* **How was the bug fixed?**
    * The language identifier for all JSON examples was changed from `js` to `json`.
    * The example product IDs in API responses were updated to be consistent with the request payloads.
    * Typographical errors in the JSON examples were corrected.

# Testing

## Setup

As this is a documentation-only change, no special setup is required. Simply pull down this branch to view the file changes.

## Main scenarios

### Scenario 1: Review the corrected documentation

1.  Check out the `chore/docs-fix-readme-json-examples` branch.
2.  Open the `README.md` file in a text editor or a Markdown previewer.
3.  Scroll to the API documentation section containing the JSON examples for adding items to the cart.
4.  **Expected outcome:** The JSON code blocks should have correct syntax highlighting. The data within the examples should be consistent (e.g., product IDs match between request and response) and free of typos. The documentation should be easier to read and understand.